### PR TITLE
fixing dependency injection issue, dateMath was being improperly load…

### DIFF
--- a/datasource.js
+++ b/datasource.js
@@ -6,7 +6,7 @@ define([
   'app/core/utils/kbn',
   './query_ctrl'
 ],
-function (angular, _, dateMath, kbn) {
+function (angular, _, sdk, dateMath, kbn) {
   'use strict';
 
   var self;


### PR DESCRIPTION
…ed and caused dateMath.parse to no longer exist, and it broke our Grafana 3.0 dashboards
