### PR TITLE
Error handling in plugin

### DIFF
--- a/src/beans/request/metric_tags.ts
+++ b/src/beans/request/metric_tags.ts
@@ -4,7 +4,7 @@ export class MetricTags {
     public tags: {[key: string]: string[]} = {};
     public size: number;
     public initialized: boolean = false;
-    public combinations: number;
+    public combinations: number = 0;
     public multiValuedTags: string[];
 
     public updateTags(tags) {

--- a/src/core/datasource.ts
+++ b/src/core/datasource.ts
@@ -81,7 +81,12 @@ export class KairosDBDatasource {
                 this.cacheResponse(hashedQuery, response.data);
                 return this.responseHandler.convertToDatapoints(response.data, aliases);
             })
-            .catch(() => this.responseHandler.convertToDatapoints(this.lastResult[hashedQuery], aliases));
+            .catch((resp) => {
+                if (this.lastResult[hashedQuery]) {
+                    return this.responseHandler.convertToDatapoints(this.lastResult[hashedQuery], aliases);
+                }
+                throw {message: resp.data.errors[0]};
+            });
     }
 
     public getMetricTags(metricNameTemplate, filters = {}) {

--- a/src/core/query_ctrl.ts
+++ b/src/core/query_ctrl.ts
@@ -62,7 +62,18 @@ export class KairosDBQueryCtrl extends QueryCtrl {
             this.datasource.getMetricTags(metricName)
                 .then(
                     (tags) => this.tags.updateTags(tags),
-                    (error) => this.tagsInitializationError = error.data.message
+                    (error) => {
+                        this.tagsInitializationError = error.data.errors[0];
+                        const defaultTags = {
+                            key: ["", ""],
+                            entity: ["", ""],
+                            application_id: ["", ""],
+                            stack_name: ["", ""],
+                            application: ["", ""],
+                            namespace : ["", ""],
+                        };
+                        this.tags.updateTags(defaultTags);
+                    }
                 );
         }
     }

--- a/src/partials/tags.editor.html
+++ b/src/partials/tags.editor.html
@@ -9,9 +9,6 @@
             <label class="gf-form-label" ng-show="!ctrl.tags.initialized">
                 Loading tags... <span class="fa fa-spinner fa-spin"></span>
             </label>
-            <!--<label class="gf-form-label" ng-if="ctrl.tagsInitializationError" style="color: red">
-                <strong>Unable to load tags: {{ctrl.tagsInitializationError}}</strong>
-            </label>-->
             <label class="gf-form-label" ng-show="ctrl.tags.initialized">
                 <b>{{ctrl.tags.size}} tags, {{ctrl.tags.combinations}} combinations</b>
             </label>

--- a/src/partials/tags.editor.html
+++ b/src/partials/tags.editor.html
@@ -9,13 +9,16 @@
             <label class="gf-form-label" ng-show="!ctrl.tags.initialized">
                 Loading tags... <span class="fa fa-spinner fa-spin"></span>
             </label>
+            <!--<label class="gf-form-label" ng-if="ctrl.tagsInitializationError" style="color: red">
+                <strong>Unable to load tags: {{ctrl.tagsInitializationError}}</strong>
+            </label>-->
             <label class="gf-form-label" ng-show="ctrl.tags.initialized">
                 <b>{{ctrl.tags.size}} tags, {{ctrl.tags.combinations}} combinations</b>
             </label>
         </div>
         <div class="gf-form" ng-if="ctrl.tagsInitializationError">
             <label class="gf-form-label" style="color: red">
-                <strong>Unable to load tags: {{ctrl.tagsInitializationError}}</strong>
+                <strong>Unable to load tags: {{ctrl.tagsInitializationError}} . Using default tags</strong>
             </label>
         </div>
         <div class="gf-form gf-form--grow">


### PR DESCRIPTION
Error handling while reading from Cache:
- Return empty data when no cache available
- Return proper error message to Grafana when no cache available

Allow tag editing when KairosDB return "too many tag" error